### PR TITLE
Fixed wrong byte order

### DIFF
--- a/sdk/PersesSDK.h
+++ b/sdk/PersesSDK.h
@@ -5,18 +5,18 @@
 
 #define PERSES_MUTATION_START() \
 {\
-	__nop();\
-	__nop();\
 	__debugbreak();\
 	__debugbreak();\
+	__nop();\
+	__nop();\
 	_disable();\
 }
 
 #define PERSES_MUTATION_END() \
 {\
 	_enable();\
-	__debugbreak();\
-	__debugbreak();\
 	__nop();\
 	__nop();\
+	__debugbreak();\
+	__debugbreak();\
 }


### PR DESCRIPTION
The order of the bytes is wrong, if we compare to the file detais.hpp at line #79, the scan will never match.